### PR TITLE
Fixed: ID is already copied in lexer.

### DIFF
--- a/src/scanparse/parser.y
+++ b/src/scanparse/parser.y
@@ -77,7 +77,7 @@ assign: varlet LET expr SEMICOLON
 
 varlet: ID
         {
-          $$ = ASTvarlet(STRcpy($1));
+          $$ = ASTvarlet($1);
           AddLocToNode($$, &@1, &@1);
         }
         ;
@@ -89,7 +89,7 @@ expr: constant
       }
     | ID
       {
-        $$ = ASTvar(STRcpy($1));
+        $$ = ASTvar($1);
       }
     | BRACKET_L expr[left] binop[type] expr[right] BRACKET_R
       {


### PR DESCRIPTION
ID's were copied twice, once in the lexer and again in the parser. Removed the STRcpy in the parser. 