### PR TITLE
Move number parsing to the parser.

### DIFF
--- a/src/scanparse/lexer.l
+++ b/src/scanparse/lexer.l
@@ -44,12 +44,12 @@ int yycolumn = 1;
 
 "-"                        { FILTER( MINUS); }
 "+"                        { FILTER( PLUS);  }
-"*"                        { FILTER( STAR);  } 
-"/"                        { FILTER( SLASH);  } 
-"%"                        { FILTER( PERCENT);  } 
+"*"                        { FILTER( STAR);  }
+"/"                        { FILTER( SLASH);  }
+"%"                        { FILTER( PERCENT);  }
 
 "<="                       { FILTER( LE);    }
-"<"                        { FILTER( LT);    } 
+"<"                        { FILTER( LT);    }
 ">="                       { FILTER( GE);    }
 ">"                        { FILTER( GT);    }
 "=="                       { FILTER( EQ);    }
@@ -62,15 +62,15 @@ int yycolumn = 1;
 "true"                     { FILTER( TRUEVAL); }
 "false"                    { FILTER( FALSEVAL); }
 
-[A-Za-z][A-Za-z0-9_]*      { yylval.id = STRcpy(yytext);
+[A-Za-z][A-Za-z0-9_]*      { yylval.value = yytext;
                              FILTER( ID);
                            }
 
-[0-9]+                     { yylval.cint=atoi(yytext);
+[0-9]+                     { yylval.value = yytext;
                              FILTER( NUM);
                            }
 
-\n.*                       { 
+\n.*                       {
                              yycolumn = 1;
                              global.line += 1;
                              global.col = 0;
@@ -78,7 +78,7 @@ int yycolumn = 1;
                            }
 
 [ \t]                      { global.col += yyleng;
-                           } 
+                           }
 %%
 
 static inline void token_action() {

--- a/src/scanparse/parser.y
+++ b/src/scanparse/parser.y
@@ -22,9 +22,7 @@ void AddLocToNode(node_st *node, void *begin_loc, void *end_loc);
 %}
 
 %union {
- char               *id;
- int                 cint;
- float               cflt;
+ char               *value;
  enum binop_type     cbinop;
  node_st             *node;
 }
@@ -35,9 +33,7 @@ void AddLocToNode(node_st *node, void *begin_loc, void *end_loc);
 %token MINUS PLUS STAR SLASH PERCENT LE LT GE GT EQ NE OR AND
 %token TRUEVAL FALSEVAL LET
 
-%token <cint> NUM
-%token <cflt> FLOAT
-%token <id> ID
+%token <value> NUM FLOAT ID
 
 %type <node> intval floatval boolval constant expr
 %type <node> stmts stmt assign varlet program
@@ -77,7 +73,7 @@ assign: varlet LET expr SEMICOLON
 
 varlet: ID
         {
-          $$ = ASTvarlet($1);
+          $$ = ASTvarlet(STRcpy($1));
           AddLocToNode($$, &@1, &@1);
         }
         ;
@@ -89,7 +85,7 @@ expr: constant
       }
     | ID
       {
-        $$ = ASTvar($1);
+        $$ = ASTvar(STRcpy($1));
       }
     | BRACKET_L expr[left] binop[type] expr[right] BRACKET_R
       {
@@ -114,13 +110,13 @@ constant: floatval
 
 floatval: FLOAT
            {
-             $$ = ASTfloat($1);
+             $$ = ASTfloat(atof($1));
            }
          ;
 
 intval: NUM
         {
-          $$ = ASTnum($1);
+          $$ = ASTnum(atoi($1));
         }
       ;
 


### PR DESCRIPTION
Currently, integers and floats are parsed in the lexer. While this works, it is not convenient when one wishes to perform error handling. This is something that should not be handled in the lexer, but rather in the parser. Moving it to the parser makes implementing error-checking a bit more intuitive.