### PR TITLE
Yacc cleanup

### DIFF
--- a/src/scanparse/parser.y
+++ b/src/scanparse/parser.y
@@ -25,7 +25,6 @@ void AddLocToNode(node_st *node, void *begin_loc, void *end_loc);
  char               *id;
  int                 cint;
  float               cflt;
- enum BinOpType     cbinop;
  node_st             *node;
 }
 
@@ -41,7 +40,6 @@ void AddLocToNode(node_st *node, void *begin_loc, void *end_loc);
 
 %type <node> intval floatval boolval constant expr
 %type <node> stmts stmt assign varlet program
-%type <cbinop> binop
 
 %start program
 
@@ -91,9 +89,64 @@ expr: constant
       {
         $$ = ASTvar($id);
       }
-    | BRACKET_L expr[left] binop[type] expr[right] BRACKET_R
+    | BRACKET_L expr[left] PLUS expr[right] BRACKET_R
       {
-        $$ = ASTbinop( $left, $right, $type);
+        $$ = ASTbinop( $left, $right, BO_add);
+        AddLocToNode($$, &@left, &@right);
+      }
+    | BRACKET_L expr[left] MINUS expr[right] BRACKET_R
+      {
+        $$ = ASTbinop( $left, $right, BO_sub);
+        AddLocToNode($$, &@left, &@right);
+      }
+    | BRACKET_L expr[left] STAR expr[right] BRACKET_R
+      {
+        $$ = ASTbinop( $left, $right, BO_mul);
+        AddLocToNode($$, &@left, &@right);
+      }
+    | BRACKET_L expr[left] SLASH expr[right] BRACKET_R
+      {
+        $$ = ASTbinop( $left, $right, BO_div);
+        AddLocToNode($$, &@left, &@right);
+      }
+    | BRACKET_L expr[left] PERCENT expr[right] BRACKET_R
+      {
+        $$ = ASTbinop( $left, $right, BO_mod);
+        AddLocToNode($$, &@left, &@right);
+      }
+    | BRACKET_L expr[left] LE expr[right] BRACKET_R
+      {
+        $$ = ASTbinop( $left, $right, BO_le);
+        AddLocToNode($$, &@left, &@right);
+      }
+    | BRACKET_L expr[left] LT expr[right] BRACKET_R
+      {
+        $$ = ASTbinop( $left, $right, BO_lt);
+        AddLocToNode($$, &@left, &@right);
+      }
+    | BRACKET_L expr[left] GE expr[right] BRACKET_R
+      {
+        $$ = ASTbinop( $left, $right, BO_ge);
+        AddLocToNode($$, &@left, &@right);
+      }
+    | BRACKET_L expr[left] GT expr[right] BRACKET_R
+      {
+        $$ = ASTbinop( $left, $right, BO_gt);
+        AddLocToNode($$, &@left, &@right);
+      }
+    | BRACKET_L expr[left] EQ expr[right] BRACKET_R
+      {
+        $$ = ASTbinop( $left, $right, BO_eq);
+        AddLocToNode($$, &@left, &@right);
+      }
+    | BRACKET_L expr[left] OR expr[right] BRACKET_R
+      {
+        $$ = ASTbinop( $left, $right, BO_or);
+        AddLocToNode($$, &@left, &@right);
+      }
+    | BRACKET_L expr[left] AND expr[right] BRACKET_R
+      {
+        $$ = ASTbinop( $left, $right, BO_and);
         AddLocToNode($$, &@left, &@right);
       }
     ;
@@ -133,20 +186,6 @@ boolval: TRUEVAL
            $$ = ASTbool(false);
          }
        ;
-
-binop: PLUS      { $$ = BO_add; }
-     | MINUS     { $$ = BO_sub; }
-     | STAR      { $$ = BO_mul; }
-     | SLASH     { $$ = BO_div; }
-     | PERCENT   { $$ = BO_mod; }
-     | LE        { $$ = BO_le; }
-     | LT        { $$ = BO_lt; }
-     | GE        { $$ = BO_ge; }
-     | GT        { $$ = BO_gt; }
-     | EQ        { $$ = BO_eq; }
-     | OR        { $$ = BO_or; }
-     | AND       { $$ = BO_and; }
-     ;
 
 %%
 


### PR DESCRIPTION
The binop non-terminal is removed and replaced with multiple binop expression grammar rules that directly use the operator tokens. Not as pretty as a separate binop non-terminal but students always ran into problems when they added operator precedence. This does not work with a separate binop non-terminal.

Also replaced positional references with named references. 