### PR TITLE
Fix warnings about function declaration without a prototype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ add_executable(civicc ${FLEX_CivicLexer_OUTPUTS} ${BISON_CivicParser_OUTPUTS}
 )
 
 target_compile_options(civicc PRIVATE
-    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -pedantic -Wno-unused-function>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -pedantic -Wno-unused-function -Wno-strict-prototypes>
 )
 
 # Enable address sanitizer


### PR DESCRIPTION
When compiling on macos, I get multiple warnings like:

```
/civicc-skeleton/coconut/copra/src/phase_driver.c:339:17: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
  339 | void CCNshowTree()
```

We can fix this by adding the `-Wno-strict-prototypes` flag to the compile options in the `CMakeLists.txt`.

Not sure if this should be added by default or if it should just be documented as a recommendation in the readme.